### PR TITLE
Attempt to clean up object URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,11 @@ MediaElementWrapper.prototype.error = function (err) {
   try {
     self._mediaSource.endOfStream('decode')
   } catch (err) {}
+
+  try {
+    // Attempt to clean up object URL
+    window.URL.revokeObjectURL(self._elem.src)
+  } catch (err) {}
 }
 
 /*


### PR DESCRIPTION
This fixes up the console errors on webtorrent.io right now, but Chrome 71 still doesn't support streaming (https://github.com/webtorrent/webtorrent/issues/1556)